### PR TITLE
Disable the APP_CONTEXT in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     depends_on:
       - stardog
     environment:
-      - "APP_CONTEXT=/sparqlab"
+#      - "APP_CONTEXT=/sparqlab"
       - "SPARQL_ENDPOINT=http://stardog:5820/sparqlab/query"
     ports:
       - "3000:3000"


### PR DESCRIPTION
The APP_CONTEXT sets the basepath for the sparqlab setup. The preset causes trouble in the default docker-compose setup and is special for the setup. So it should be disables by default. Letting it commentd in the docker-compose file still gives people a hint about the option.